### PR TITLE
Sign binaries with DigiCert.

### DIFF
--- a/SignBinary.cmd
+++ b/SignBinary.cmd
@@ -15,7 +15,7 @@ GOTO NoSign
 :Sign
 echo SignBinary.cmd: %CONFIGURATION% - Signing binary %TARGET_PATH%
 if "%SIGNTOOL_DIR%" == "" GOTO SigntoolPath
-"%SIGNTOOL_DIR%\signtool" sign /debug /a /t http://timestamp.verisign.com/scripts/timstamp.dll %TARGET_PATH%
+"%SIGNTOOL_DIR%\signtool" sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a %TARGET_PATH%
 GOTO DoneSigning
 
 :NoSign


### PR DESCRIPTION
Some repos (including aris-applications) still reference this repo as a submodule and use SignBinary.cmd to sign binaries.  Addresses #8.  